### PR TITLE
Resolve `aborted: you must first push the current branch to a remote, or use the --head flag` error

### DIFF
--- a/backport
+++ b/backport
@@ -181,8 +181,8 @@ gh pr create \
   --base "${BASE_BRANCH}" \
   --title "${NEW_COMMIT_MSG}" \
   --body "Backport of ${ORIGINAL_PR_URL}$(echo -e "\n\n")${PR_BODY}" \
-  --assignee "${GITHUB_ACTOR:-@me}" \ \
-  --head $(git branch --show-current)
+  --assignee "${GITHUB_ACTOR:-@me}" \
+  --head $(git branch --show-current) \
   ${REVIEWERS_ARG} \
   "${LABELS_ARG[@]}" \
   $( [ "$(check_if_milestone_in_repo ${REPO_UPSTREAM} ${SUFFIX})" == "true" ] && echo "--milestone ${SUFFIX}" ) \

--- a/backport
+++ b/backport
@@ -181,7 +181,8 @@ gh pr create \
   --base "${BASE_BRANCH}" \
   --title "${NEW_COMMIT_MSG}" \
   --body "Backport of ${ORIGINAL_PR_URL}$(echo -e "\n\n")${PR_BODY}" \
-  --assignee "${GITHUB_ACTOR:-@me}" \
+  --assignee "${GITHUB_ACTOR:-@me}" \ \
+  --head $(git branch --show-current)
   ${REVIEWERS_ARG} \
   "${LABELS_ARG[@]}" \
   $( [ "$(check_if_milestone_in_repo ${REPO_UPSTREAM} ${SUFFIX})" == "true" ] && echo "--milestone ${SUFFIX}" ) \


### PR DESCRIPTION
During [a backport, an error was thrown](https://github.com/hazelcast/hz-docs/actions/runs/14926707178/job/41933151646):
> Creating new PR...
aborted: you must first push the current branch to a remote, or use the --head flag Error: Process completed with exit code 1.

The branch has _already_ been `push`ed and this looks to be a [known bug](https://github.com/cli/cli/issues/6485#issuecomment-1517886614).

Adding suggested workaround.